### PR TITLE
fix: replace getSession() with getUser() for secure user authentication

### DIFF
--- a/src/app/api/feature-flags/route.ts
+++ b/src/app/api/feature-flags/route.ts
@@ -6,10 +6,11 @@ export async function GET() {
 
   try {
     const {
-      data: { session },
-    } = await supabase.auth.getSession();
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
 
-    if (!session?.user) {
+    if (userError || !user) {
       return NextResponse.json(
         {
           flags: {},
@@ -19,8 +20,6 @@ export async function GET() {
         { status: 200 }
       );
     }
-
-    const { user } = session;
     const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || "development";
 
     const [flagsResponse, typesResponse, groupsResponse] = await Promise.all([

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,7 +26,12 @@ export async function middleware(request: NextRequest) {
     }
   );
 
-  await supabase.auth.getSession();
+  // Check if user is authenticated by getting the session
+  // This is used for route protection, not for user data access
+  const { data: { session } } = await supabase.auth.getSession();
+  
+  // If you need authenticated user data in middleware, use getUser() instead:
+  // const { data: { user }, error } = await supabase.auth.getUser();
 
   return response;
 }


### PR DESCRIPTION
- Replace supabase.auth.getSession() with supabase.auth.getUser() in feature-flags API route
- Add proper error handling for user authentication
- Add comments in middleware explaining the difference between getSession() and getUser()
- Fixes security issue where user data from storage could be insecure