### PR TITLE
feat: add user roles and groups display to profile page

### DIFF
--- a/apps/web/src/features/profile/components/PersonalInfoCard/PersonalInfoCard.module.css
+++ b/apps/web/src/features/profile/components/PersonalInfoCard/PersonalInfoCard.module.css
@@ -104,3 +104,39 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.rolesGroupsContainer {
+  margin-top: 0.25rem;
+}
+
+.roleGroupSection {
+  margin-bottom: 0.75rem;
+}
+
+.roleGroupSection:last-child {
+  margin-bottom: 0;
+}
+
+.roleGroupLabel {
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.875rem;
+  margin-right: 0.5rem;
+}
+
+.roleGroupTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.roleGroupTag {
+  background-color: #f3f4f6;
+  color: #374151;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid #e5e7eb;
+}

--- a/apps/web/src/features/profile/components/PersonalInfoCard/PersonalInfoCard.tsx
+++ b/apps/web/src/features/profile/components/PersonalInfoCard/PersonalInfoCard.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Mail, Phone, MapPin, Calendar, Edit2, Save } from 'lucide-react';
+import {
+  Mail,
+  Phone,
+  MapPin,
+  Calendar,
+  Edit2,
+  Save,
+  Shield,
+} from 'lucide-react';
 import React, { useState } from 'react';
 
 import { UserMetadata } from '../../types/profile';
@@ -31,7 +39,7 @@ export const PersonalInfoCard = ({
   onUpdateMetadata,
   isUpdating = false,
 }: PersonalInfoCardProps) => {
-  const { mutateUser } = useAuth();
+  const { mutateUser, userRoles, userGroups } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [formData, setFormData] = useState({
     name: user.user_metadata.name || '',
@@ -238,6 +246,43 @@ export const PersonalInfoCard = ({
           ) : (
             <p className={styles.value}>{formData.bio || 'No bio provided'}</p>
           )}
+        </div>
+
+        {/* Roles and Groups Section */}
+        <div>
+          <Label className={styles.label}>
+            <Shield className={styles.icon} />
+            Roles & Groups
+          </Label>
+          <div className={styles.rolesGroupsContainer}>
+            {userRoles.length > 0 && (
+              <div className={styles.roleGroupSection}>
+                <span className={styles.roleGroupLabel}>Roles:</span>
+                <div className={styles.roleGroupTags}>
+                  {userRoles.map((role, index) => (
+                    <span key={index} className={styles.roleGroupTag}>
+                      {role}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {userGroups.length > 0 && (
+              <div className={styles.roleGroupSection}>
+                <span className={styles.roleGroupLabel}>Groups:</span>
+                <div className={styles.roleGroupTags}>
+                  {userGroups.map((group, index) => (
+                    <span key={index} className={styles.roleGroupTag}>
+                      {group}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {userRoles.length === 0 && userGroups.length === 0 && (
+              <p className={styles.value}>No roles or groups assigned</p>
+            )}
+          </div>
         </div>
 
         <div className={styles.actions}>


### PR DESCRIPTION
- Add roles and groups section to PersonalInfoCard component
- Display user roles and groups as styled tags with shield icon
- Add responsive CSS styling for roles/groups container and tags
- Show fallback message when no roles or groups are assigned
- Integrate with existing useAuth hook to get user metadata