### PR TITLE
fix: redirect users to dashboard instead of profile after login

### DIFF
--- a/apps/web/src/features/auth/context/AuthContext.tsx
+++ b/apps/web/src/features/auth/context/AuthContext.tsx
@@ -173,9 +173,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [supabase, handleAuthChange]);
 
   const getAuthRedirectPath = () => {
-    // Default to profile as a safe fallback that doesn't depend on feature flags
+    // Default to dashboard as the main landing page after authentication
     // In a real app, you might want to check feature flags here
-    return '/profile';
+    return '/dashboard';
   };
 
   const login = async (email?: string, password?: string) => {


### PR DESCRIPTION
- Changed getAuthRedirectPath() to return '/dashboard' instead of '/profile'
- This ensures users are redirected to the main dashboard page after successful authentication
- Both login and signup flows now redirect to dashboard consistently