### PR TITLE
fix: resolve muscle groups type casting error in routine creation

### DIFF
--- a/supabase/migrations/006_create_comprehensive_routine_creation.sql
+++ b/supabase/migrations/006_create_comprehensive_routine_creation.sql
@@ -92,7 +92,14 @@ BEGIN
               new_section_id,
               exercise_record->>'name',
               exercise_record->>'category',
-              exercise_record->'muscleGroups',
+              COALESCE(
+                CASE 
+                  WHEN exercise_record->'muscleGroups' IS NOT NULL 
+                  THEN (exercise_record->'muscleGroups')::TEXT[]
+                  ELSE ARRAY[]::TEXT[]
+                END,
+                ARRAY[]::TEXT[]
+              ),
               COALESCE(exercise_record->>'variantId', exercise_record->>'exerciseId'),
               (exercise_record->>'orderIndex')::INTEGER,
               COALESCE((exercise_record->>'restTimer')::INTEGER, 0),
@@ -182,7 +189,14 @@ BEGIN
               new_section_id,
               exercise_record->>'name',
               exercise_record->>'category',
-              exercise_record->'muscleGroups',
+              COALESCE(
+                CASE 
+                  WHEN exercise_record->'muscleGroups' IS NOT NULL 
+                  THEN (exercise_record->'muscleGroups')::TEXT[]
+                  ELSE ARRAY[]::TEXT[]
+                END,
+                ARRAY[]::TEXT[]
+              ),
               (exercise_record->>'orderIndex')::INTEGER,
               COALESCE((exercise_record->>'restTimer')::INTEGER, 0),
               COALESCE((exercise_record->>'restAfter')::INTEGER, 0),


### PR DESCRIPTION
- Fixed the create_complete_routine database function to properly handle muscleGroups as TEXT[] array
- Added proper COALESCE and CASE handling for muscleGroups casting
- Applied the same fix to both strength and running workout sections
- This resolves the 'cannot cast type json to text[]' error when creating routines