### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: CI
 permissions:
   contents: read
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/erikpr1994/peakHealth/security/code-scanning/14](https://github.com/erikpr1994/peakHealth/security/code-scanning/14)

To fix this issue, explicitly set the `permissions` key in the workflow. The ideal location is at the root level, so all jobs inherit the minimal permissions unless overridden.  
- Add a block near the top of `.github/workflows/ci.yml` (after the `name:` and before `on:`), like:
  ```yaml
  permissions:
    contents: read
  ```
- This will restrict the default permissions of GITHUB_TOKEN for all jobs to read-only for repository contents.
- If any job needs elevated permissions (such as `pull-requests: write` for automations), then a more specific block should be added under that job. In this workflow, all jobs can operate with contents: read, as they are doing builds, linting, testing, uploading artifacts—not pushing, deploying, or creating issues/pull requests.

**File to change:** `.github/workflows/ci.yml`  
**Change type:** Insert a `permissions` block after the workflow `name:` declaration, before the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
