### PR TITLE
Fix: Handle file paths with parentheses in lint script

### DIFF
--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { spawn } from 'child_process';
 
 // Set the ESLint feature flag
 process.env.ESLINT_FLAGS = 'v10_config_lookup_from_file';
@@ -8,12 +8,18 @@ process.env.ESLINT_FLAGS = 'v10_config_lookup_from_file';
 // Get the arguments passed to this script
 const args = process.argv.slice(2);
 
-// Run ESLint with the provided arguments
-try {
-  execSync(`pnpm exec eslint ${args.join(' ')}`, {
-    stdio: 'inherit',
-    env: process.env,
-  });
-} catch (error) {
-  process.exit(error.status || 1);
-}
+// Run ESLint with the provided arguments using spawn to avoid shell interpretation issues
+const eslintProcess = spawn('pnpm', ['exec', 'eslint', ...args], {
+  stdio: 'inherit',
+  env: process.env,
+  shell: false, // Don't use shell to avoid special character interpretation
+});
+
+eslintProcess.on('close', code => {
+  process.exit(code || 0);
+});
+
+eslintProcess.on('error', error => {
+  process.stderr.write(`Failed to start ESLint process: ${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Fix: Handle file paths with parentheses in lint script

### Problem
The lint script was failing when file paths contained parentheses, which is common in Next.js applications with route groups like `(auth)`, `(app)`, etc. This caused issues when `lint-staged` tried to process files in these directories.

### Root Cause
The script was using `execSync` with a shell command string, which caused the shell to interpret parentheses as special characters for command substitution or grouping.

### Solution
- Replaced `execSync` with `spawn` to avoid shell interpretation
- Set `shell: false` to prevent special character processing  
- Pass arguments directly as an array instead of a shell command string

### Testing
- ✅ Verified the fix works with files containing parentheses in their paths
- ✅ Confirmed the script no longer produces shell syntax errors
- ✅ Tested with actual Next.js route files like `apps/auth/src/app/[locale]/(auth)/page.tsx`

### Impact
This fix ensures that `lint-staged` will work correctly when processing files in Next.js route directories that contain parentheses, preventing the shell interpretation errors that were occurring before. 