### PR TITLE
feat(ui): create generic Accordion compound component

### DIFF
--- a/packages/ui/exports.json
+++ b/packages/ui/exports.json
@@ -4,6 +4,11 @@
     "import": "./dist/index.js",
     "require": "./dist/index.js"
   },
+  "./accordion": {
+    "types": "./dist/components/accordion/index.d.ts",
+    "import": "./dist/components/accordion/index.js",
+    "require": "./dist/components/accordion/index.js"
+  },
   "./alert": {
     "types": "./dist/components/alert/index.d.ts",
     "import": "./dist/components/alert/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
+    "./accordion": {
+      "types": "./dist/components/accordion/index.d.ts",
+      "import": "./dist/components/accordion/index.js",
+      "require": "./dist/components/accordion/index.js"
+    },
     "./alert": {
       "types": "./dist/components/alert/index.d.ts",
       "import": "./dist/components/alert/index.js",

--- a/packages/ui/src/components/accordion/Accordion.stories.test.tsx
+++ b/packages/ui/src/components/accordion/Accordion.stories.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import { describe, it } from 'vitest';
+import * as stories from './Accordion.stories';
+
+const { Default } = composeStories(stories);
+
+describe('Accordion Stories', () => {
+  it('should render the default story', () => {
+    render(<Default />);
+    screen.getByText('Is it accessible?');
+    screen.getByText('Yes. It adheres to the WAI-ARIA design pattern.');
+  });
+});

--- a/packages/ui/src/components/accordion/Accordion.stories.tsx
+++ b/packages/ui/src/components/accordion/Accordion.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Accordion } from './';
+
+const meta: Meta<typeof Accordion> = {
+  title: 'UI/Accordion',
+  component: Accordion,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion>
+      <Accordion.Header>Is it accessible?</Accordion.Header>
+      <Accordion.Content>
+        Yes. It adheres to the WAI-ARIA design pattern.
+      </Accordion.Content>
+    </Accordion>
+  ),
+};

--- a/packages/ui/src/components/accordion/Accordion.tsx
+++ b/packages/ui/src/components/accordion/Accordion.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import {
+  type ComponentProps,
+  type FC,
+  type PropsWithChildren,
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import './accordion.css';
+
+interface AccordionContextProps {
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+const AccordionContext = createContext<AccordionContextProps | undefined>(
+  undefined
+);
+
+const useAccordionContext = (): AccordionContextProps => {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error(
+      'useAccordionContext must be used within an Accordion component'
+    );
+  }
+  return context;
+};
+
+interface AccordionProps extends ComponentProps<'div'> {
+  // Add any additional props here
+}
+
+const AccordionContent: FC<PropsWithChildren<AccordionProps>> = ({
+  children,
+}): ReactNode => {
+  const { isOpen } = useAccordionContext();
+  return isOpen ? <div className="content">{children}</div> : null;
+};
+
+AccordionContent.displayName = 'Accordion.Content';
+
+const AccordionHeader: FC<PropsWithChildren<AccordionProps>> = ({
+  children,
+}): ReactNode => {
+  const { toggle } = useAccordionContext();
+  return (
+    <div className="header" onClick={toggle}>
+      {children}
+    </div>
+  );
+};
+
+AccordionHeader.displayName = 'Accordion.Header';
+
+const Accordion: FC<PropsWithChildren<AccordionProps>> & {
+  Header: FC<PropsWithChildren<AccordionProps>>;
+  Content: FC<PropsWithChildren<AccordionProps>>;
+} = ({ children }): ReactNode => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = useCallback(() => {
+    setIsOpen(prevOpen => !prevOpen);
+  }, []);
+
+  const value = useMemo(() => ({ isOpen, toggle }), [isOpen, toggle]);
+
+  return (
+    <AccordionContext.Provider value={value}>
+      <div className="accordion">{children}</div>
+    </AccordionContext.Provider>
+  );
+};
+
+Accordion.displayName = 'Accordion';
+Accordion.Header = AccordionHeader;
+Accordion.Content = AccordionContent;
+
+export default Accordion;

--- a/packages/ui/src/components/accordion/Accordion.tsx
+++ b/packages/ui/src/components/accordion/Accordion.tsx
@@ -1,21 +1,34 @@
 'use client';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { clsx } from 'clsx';
 import './accordion.css';
 
 interface AccordionProps extends ComponentProps<'details'> {}
 
 const AccordionContent: FC<PropsWithChildren<ComponentProps<'div'>>> = ({
   children,
+  className,
+  ...props
 }) => {
-  return <div className="content">{children}</div>;
+  return (
+    <div className={clsx('content', className)} {...props}>
+      {children}
+    </div>
+  );
 };
 
 AccordionContent.displayName = 'Accordion.Content';
 
 const AccordionHeader: FC<PropsWithChildren<ComponentProps<'summary'>>> = ({
   children,
+  className,
+  ...props
 }) => {
-  return <summary className="header">{children}</summary>;
+  return (
+    <summary className={clsx('header', className)} {...props}>
+      {children}
+    </summary>
+  );
 };
 
 AccordionHeader.displayName = 'Accordion.Header';

--- a/packages/ui/src/components/accordion/Accordion.tsx
+++ b/packages/ui/src/components/accordion/Accordion.tsx
@@ -1,79 +1,33 @@
 'use client';
-
-import {
-  type ComponentProps,
-  type FC,
-  type PropsWithChildren,
-  type ReactNode,
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import './accordion.css';
 
-interface AccordionContextProps {
-  isOpen: boolean;
-  toggle: () => void;
-}
+interface AccordionProps extends ComponentProps<'details'> {}
 
-const AccordionContext = createContext<AccordionContextProps | undefined>(
-  undefined
-);
-
-const useAccordionContext = (): AccordionContextProps => {
-  const context = useContext(AccordionContext);
-  if (!context) {
-    throw new Error(
-      'useAccordionContext must be used within an Accordion component'
-    );
-  }
-  return context;
-};
-
-interface AccordionProps extends ComponentProps<'div'> {
-  // Add any additional props here
-}
-
-const AccordionContent: FC<PropsWithChildren<AccordionProps>> = ({
+const AccordionContent: FC<PropsWithChildren<ComponentProps<'div'>>> = ({
   children,
-}): ReactNode => {
-  const { isOpen } = useAccordionContext();
-  return isOpen ? <div className="content">{children}</div> : null;
+}) => {
+  return <div className="content">{children}</div>;
 };
 
 AccordionContent.displayName = 'Accordion.Content';
 
-const AccordionHeader: FC<PropsWithChildren<AccordionProps>> = ({
+const AccordionHeader: FC<PropsWithChildren<ComponentProps<'summary'>>> = ({
   children,
-}): ReactNode => {
-  const { toggle } = useAccordionContext();
-  return (
-    <div className="header" onClick={toggle}>
-      {children}
-    </div>
-  );
+}) => {
+  return <summary className="header">{children}</summary>;
 };
 
 AccordionHeader.displayName = 'Accordion.Header';
 
 const Accordion: FC<PropsWithChildren<AccordionProps>> & {
-  Header: FC<PropsWithChildren<AccordionProps>>;
-  Content: FC<PropsWithChildren<AccordionProps>>;
-} = ({ children }): ReactNode => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const toggle = useCallback(() => {
-    setIsOpen(prevOpen => !prevOpen);
-  }, []);
-
-  const value = useMemo(() => ({ isOpen, toggle }), [isOpen, toggle]);
-
+  Header: FC<PropsWithChildren<ComponentProps<'summary'>>>;
+  Content: FC<PropsWithChildren<ComponentProps<'div'>>>;
+} = ({ children, ...props }) => {
   return (
-    <AccordionContext.Provider value={value}>
-      <div className="accordion">{children}</div>
-    </AccordionContext.Provider>
+    <details className="accordion" {...props}>
+      {children}
+    </details>
   );
 };
 

--- a/packages/ui/src/components/accordion/accordion.css
+++ b/packages/ui/src/components/accordion/accordion.css
@@ -1,10 +1,10 @@
-.accordion {
+details.accordion {
   border: 1px solid #ccc;
   border-radius: 4px;
   margin-bottom: 1rem;
 }
 
-.header {
+summary.header {
   background-color: #f1f1f1;
   padding: 1rem;
   cursor: pointer;

--- a/packages/ui/src/components/accordion/accordion.css
+++ b/packages/ui/src/components/accordion/accordion.css
@@ -1,0 +1,19 @@
+.accordion {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.header {
+  background-color: #f1f1f1;
+  padding: 1rem;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.content {
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+}

--- a/packages/ui/src/components/accordion/accordion.test.tsx
+++ b/packages/ui/src/components/accordion/accordion.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Accordion } from './';
+
+describe('Accordion', () => {
+  it('should render the header and content', () => {
+    render(
+      <Accordion>
+        <Accordion.Header>Header</Accordion.Header>
+        <Accordion.Content>Content</Accordion.Content>
+      </Accordion>
+    );
+
+    expect(screen.getByText('Header')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/accordion/index.ts
+++ b/packages/ui/src/components/accordion/index.ts
@@ -1,0 +1,1 @@
+export { default as Accordion } from './Accordion';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/select';
 export * from './components/textarea';
 export * from './components/toast';
 export * from './components/tooltip';
+export * from './components/accordion';
 
 // Utilities
 export * from './utils';


### PR DESCRIPTION
Closes FRO-14

This PR introduces a generic `Accordion` compound component to the shared `@peakhealth/ui` package.

Following the user's feedback, the component has been refactored to use native HTML `<details>` and `<summary>` elements. This approach simplifies the implementation, removes the need for client-side state management, and improves accessibility by default.

### Key Changes:
- Created the `Accordion` compound component (`Accordion`, `Accordion.Header`, `Accordion.Content`).
- Placed the component in `packages/ui/src/components/accordion/`.
- Used native `<details>` and `<summary>` elements for the core functionality.
- Added basic styling in `accordion.css`.
- Exported the component from the main `@peakhealth/ui` package index.

**Relevant Doc**: [Accordion Component Documentation](https://github.com/erikpr1994/peakHealth/blob/main/docs/features/routines/frontend/shared/components/accordion.md)
**Linear Task**: [FRO-14](https://linear.app/peak-health/issue/FRO-14/fro-31-ui-create-generic-accordion-compound-component)
