### PR TITLE
Chore: Remove unnecessary Vite dependency from routines service

### DIFF
--- a/services/routines/package.json
+++ b/services/routines/package.json
@@ -27,7 +27,6 @@
     "@types/supertest": "^6.0.2",
     "supertest": "^6.3.4",
     "typescript": "^5.9.2",
-    "vite": "^7.1.4",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
# Chore: Remove unnecessary Vite dependency from routines service

## Overview
Removes the unnecessary Vite dependency from the `@peakhealth/routines-api` service package, as it's a Node.js backend service that doesn't require frontend bundling.

## Changes Made
- **Removed Vite** from `devDependencies` in `services/routines/package.json`
- **Kept Vitest** for testing functionality (which is still needed)
- **No functional changes** to the service

## Why This Change
The `@routines/` package is a **backend API service** that:
- Runs on Node.js with Express
- Uses TypeScript compiler (`tsc`) for building
- Doesn't need frontend bundling or development server features
- Only requires Vitest for running tests

## Testing
- ✅ All existing tests continue to pass
- ✅ Build process (`tsc && node dist/index.js`) works correctly
- ✅ Service functionality remains unchanged

## Impact
- **No breaking changes** for consumers of the service
- **Reduced package size** and dependency tree
- **Cleaner separation** between frontend and backend packages
- **Faster installs** due to fewer unnecessary dependencies

## Related
This cleanup aligns with the monorepo architecture where:
- Frontend packages (`@web`, `@landing`, `@ui`, `@routines-ui`) use Vite
- Backend services (`@routines-api`) use Node.js tooling
